### PR TITLE
🧹 Remove unused unexported function extractQuestionName

### DIFF
--- a/internal/dnsproxy/dns_proxy.go
+++ b/internal/dnsproxy/dns_proxy.go
@@ -283,11 +283,6 @@ func (p *DNSProxy) forwardTCP(payload []byte) ([]byte, error) {
 	return nil, fmt.Errorf("all upstreams failed: %v", lastErr)
 }
 
-func extractQuestionName(msg []byte) (string, error) {
-	name, _, err := parseDNSQuestion(msg)
-	return name, err
-}
-
 func parseDNSQuestion(msg []byte) (string, string, error) {
 	var p dnsmessage.Parser
 	if _, err := p.Start(msg); err != nil {


### PR DESCRIPTION
🎯 **What:** Removed the unused unexported function `extractQuestionName` from `internal/dnsproxy/dns_proxy.go`.
💡 **Why:** It's an unexported utility function that has fallen out of use and removing it is non-breaking, improving codebase cleanliness and readability.
✅ **Verification:** Verified by running `grep` to ensure no usages remain, running `gofmt` and `go vet` for code health, and running the full `go test ./...` suite to confirm no regressions were introduced. Also ensured test artifact modifications (`tests/ca-cert.pem`, `tests/ca-key.pem`) were excluded from the commit.
✨ **Result:** A cleaner codebase with less dead code, reducing confusion and maintenance overhead.

---
*PR created automatically by Jules for task [5160091993403361190](https://jules.google.com/task/5160091993403361190) started by @dmitryporotnikov*