### PR TITLE
🧹 Refactor LogHTTPResponse and LogHTTPSResponse parameter list

### DIFF
--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -428,22 +428,33 @@ func LogHTTPSRequest(sourceIP, fqdn, method, url string, headers http.Header, bo
 	return id
 }
 
+// ResponseLogEntry encapsulates the parameters for logging an HTTP/HTTPS response.
+type ResponseLogEntry struct {
+	ReqID       int64
+	SourceIP    string
+	FQDN        string
+	Status      string
+	Headers     http.Header
+	BodyPreview []byte
+	Truncated   bool
+}
+
 // LogHTTPResponse writes HTTP response details to SQLite.
-func LogHTTPResponse(reqID int64, sourceIP, fqdn, status string, headers http.Header, bodyPreview []byte, truncated bool) {
+func LogHTTPResponse(entry ResponseLogEntry) {
 	if !trafficLoggingEnabled.Load() {
 		return
 	}
-	analysis := analyzeBodyPreview(headers, bodyPreview)
-	artifactPath := maybeStoreBodyArtifact("http_response", reqID, sourceIP, fqdn, analysis, bodyPreview, truncated)
-	content := formatContentWithAnalysis(headers, bodyPreview, truncated, analysis, artifactPath)
-	insertResponse(reqID, sourceIP, fqdn, status, content)
+	analysis := analyzeBodyPreview(entry.Headers, entry.BodyPreview)
+	artifactPath := maybeStoreBodyArtifact("http_response", entry.ReqID, entry.SourceIP, entry.FQDN, analysis, entry.BodyPreview, entry.Truncated)
+	content := formatContentWithAnalysis(entry.Headers, entry.BodyPreview, entry.Truncated, analysis, artifactPath)
+	insertResponse(entry.ReqID, entry.SourceIP, entry.FQDN, entry.Status, content)
 
 	if pcap.GlobalManager != nil {
 		var sb strings.Builder
 		sb.WriteString("HTTP/1.1 ")
-		sb.WriteString(status)
+		sb.WriteString(entry.Status)
 		sb.WriteString("\r\n")
-		for k, v := range headers {
+		for k, v := range entry.Headers {
 			for _, val := range v {
 				sb.WriteString(k)
 				sb.WriteString(": ")
@@ -452,27 +463,27 @@ func LogHTTPResponse(reqID int64, sourceIP, fqdn, status string, headers http.He
 			}
 		}
 		sb.WriteString("\r\n")
-		fullRes := append([]byte(sb.String()), bodyPreview...)
-		pcap.GlobalManager.WriteResponse(reqID, sourceIP, fqdn, fullRes)
+		fullRes := append([]byte(sb.String()), entry.BodyPreview...)
+		pcap.GlobalManager.WriteResponse(entry.ReqID, entry.SourceIP, entry.FQDN, fullRes)
 	}
 }
 
 // LogHTTPSResponse writes HTTPS response details to SQLite.
-func LogHTTPSResponse(reqID int64, sourceIP, fqdn, status string, headers http.Header, bodyPreview []byte, truncated bool) {
+func LogHTTPSResponse(entry ResponseLogEntry) {
 	if !trafficLoggingEnabled.Load() {
 		return
 	}
-	analysis := analyzeBodyPreview(headers, bodyPreview)
-	artifactPath := maybeStoreBodyArtifact("https_response", reqID, sourceIP, fqdn, analysis, bodyPreview, truncated)
-	content := formatContentWithAnalysis(headers, bodyPreview, truncated, analysis, artifactPath)
-	insertResponse(reqID, sourceIP, fqdn, status, content)
+	analysis := analyzeBodyPreview(entry.Headers, entry.BodyPreview)
+	artifactPath := maybeStoreBodyArtifact("https_response", entry.ReqID, entry.SourceIP, entry.FQDN, analysis, entry.BodyPreview, entry.Truncated)
+	content := formatContentWithAnalysis(entry.Headers, entry.BodyPreview, entry.Truncated, analysis, artifactPath)
+	insertResponse(entry.ReqID, entry.SourceIP, entry.FQDN, entry.Status, content)
 
 	if pcap.GlobalManager != nil {
 		var sb strings.Builder
 		sb.WriteString("HTTP/1.1 ")
-		sb.WriteString(status)
+		sb.WriteString(entry.Status)
 		sb.WriteString("\r\n")
-		for k, v := range headers {
+		for k, v := range entry.Headers {
 			for _, val := range v {
 				sb.WriteString(k)
 				sb.WriteString(": ")
@@ -481,8 +492,8 @@ func LogHTTPSResponse(reqID int64, sourceIP, fqdn, status string, headers http.H
 			}
 		}
 		sb.WriteString("\r\n")
-		fullRes := append([]byte(sb.String()), bodyPreview...)
-		pcap.GlobalManager.WriteResponse(reqID, sourceIP, fqdn, fullRes)
+		fullRes := append([]byte(sb.String()), entry.BodyPreview...)
+		pcap.GlobalManager.WriteResponse(entry.ReqID, entry.SourceIP, entry.FQDN, fullRes)
 	}
 }
 

--- a/internal/logger/logging_toggle_test.go
+++ b/internal/logger/logging_toggle_test.go
@@ -31,7 +31,15 @@ func TestTrafficLoggingToggleSkipsDBWrites(t *testing.T) {
 	if reqID <= 0 {
 		t.Fatalf("request id = %d, want > 0", reqID)
 	}
-	LogHTTPResponse(reqID, "192.0.2.10", "example.com", "200 OK", http.Header{}, []byte("ok"), false)
+	LogHTTPResponse(ResponseLogEntry{
+		ReqID:       reqID,
+		SourceIP:    "192.0.2.10",
+		FQDN:        "example.com",
+		Status:      "200 OK",
+		Headers:     http.Header{},
+		BodyPreview: []byte("ok"),
+		Truncated:   false,
+	})
 
 	if got := countRows(t, db, "Requests"); got != 1 {
 		t.Fatalf("requests rows = %d, want 1", got)
@@ -45,7 +53,15 @@ func TestTrafficLoggingToggleSkipsDBWrites(t *testing.T) {
 	if disabledReqID != 0 {
 		t.Fatalf("request id with logging disabled = %d, want 0", disabledReqID)
 	}
-	LogHTTPResponse(disabledReqID, "192.0.2.11", "example.org", "200 OK", http.Header{}, []byte("ok"), false)
+	LogHTTPResponse(ResponseLogEntry{
+		ReqID:       disabledReqID,
+		SourceIP:    "192.0.2.11",
+		FQDN:        "example.org",
+		Status:      "200 OK",
+		Headers:     http.Header{},
+		BodyPreview: []byte("ok"),
+		Truncated:   false,
+	})
 	LogBypassedRequest("192.0.2.12", "bypass.test")
 	LogBypassedResponse(0, "192.0.2.12", "bypass.test")
 

--- a/internal/proxy/http_handler.go
+++ b/internal/proxy/http_handler.go
@@ -139,7 +139,15 @@ func (h *HTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		reqID := logger.LogHTTPRequest(sourceIP, targetHost, r.Method, fullURL, r.Header, bodyBytes)
 		logger.LogInfo(fmt.Sprintf("Blocked HTTP host %s from %s", targetHost, sourceIP))
 		writePlainError(w, http.StatusForbidden, "Blocked")
-		logger.LogHTTPResponse(reqID, sourceIP, targetHost, "403 Forbidden", http.Header{}, []byte("Blocked"), false)
+		logger.LogHTTPResponse(logger.ResponseLogEntry{
+			ReqID:       reqID,
+			SourceIP:    sourceIP,
+			FQDN:        targetHost,
+			Status:      "403 Forbidden",
+			Headers:     http.Header{},
+			BodyPreview: []byte("Blocked"),
+			Truncated:   false,
+		})
 		return
 	}
 
@@ -179,7 +187,15 @@ func (h *HTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		if bypassed {
 			logger.LogBypassedResponse(reqID, sourceIP, targetHost)
 		} else {
-			logger.LogHTTPResponse(reqID, sourceIP, targetHost, "502 Bad Gateway", http.Header{}, []byte("Bad Gateway"), false)
+			logger.LogHTTPResponse(logger.ResponseLogEntry{
+				ReqID:       reqID,
+				SourceIP:    sourceIP,
+				FQDN:        targetHost,
+				Status:      "502 Bad Gateway",
+				Headers:     http.Header{},
+				BodyPreview: []byte("Bad Gateway"),
+				Truncated:   false,
+			})
 		}
 		return
 	}
@@ -211,7 +227,15 @@ func (h *HTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			if err != nil {
 				logger.LogError(fmt.Sprintf("Failed reading upstream response body: %v", err))
 				writePlainError(w, http.StatusBadGateway, "Bad Gateway")
-				logger.LogHTTPResponse(reqID, sourceIP, targetHost, "502 Bad Gateway", http.Header{}, []byte("Bad Gateway"), false)
+				logger.LogHTTPResponse(logger.ResponseLogEntry{
+					ReqID:       reqID,
+					SourceIP:    sourceIP,
+					FQDN:        targetHost,
+					Status:      "502 Bad Gateway",
+					Headers:     http.Header{},
+					BodyPreview: []byte("Bad Gateway"),
+					Truncated:   false,
+				})
 				return
 			}
 
@@ -227,7 +251,15 @@ func (h *HTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				tee := io.TeeReader(resp.Body, preview)
 				_, _ = io.Copy(w, tee)
 
-				logger.LogHTTPResponse(reqID, sourceIP, targetHost, resp.Status, resp.Header, preview.Bytes(), preview.Truncated())
+				logger.LogHTTPResponse(logger.ResponseLogEntry{
+					ReqID:       reqID,
+					SourceIP:    sourceIP,
+					FQDN:        targetHost,
+					Status:      resp.Status,
+					Headers:     resp.Header,
+					BodyPreview: preview.Bytes(),
+					Truncated:   preview.Truncated(),
+				})
 				logger.LogDebug(fmt.Sprintf("HTTP completed (tamper skipped: body too large): %s %s -> %d", r.Method, r.URL.String(), resp.StatusCode))
 				return
 			}
@@ -247,7 +279,15 @@ func (h *HTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 			preview := &logger.LimitedBuffer{Max: logger.LogBodyLimit()}
 			_, _ = preview.Write(outBody)
-			logger.LogHTTPResponse(reqID, sourceIP, targetHost, resp.Status, resp.Header, preview.Bytes(), preview.Truncated())
+			logger.LogHTTPResponse(logger.ResponseLogEntry{
+				ReqID:       reqID,
+				SourceIP:    sourceIP,
+				FQDN:        targetHost,
+				Status:      resp.Status,
+				Headers:     resp.Header,
+				BodyPreview: preview.Bytes(),
+				Truncated:   preview.Truncated(),
+			})
 			logger.LogDebug(fmt.Sprintf("HTTP completed (tampered): %s %s -> %d", r.Method, r.URL.String(), resp.StatusCode))
 			return
 		}
@@ -260,7 +300,15 @@ func (h *HTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	tee := io.TeeReader(resp.Body, preview)
 	_, _ = io.Copy(w, tee)
 
-	logger.LogHTTPResponse(reqID, sourceIP, targetHost, resp.Status, resp.Header, preview.Bytes(), preview.Truncated())
+	logger.LogHTTPResponse(logger.ResponseLogEntry{
+		ReqID:       reqID,
+		SourceIP:    sourceIP,
+		FQDN:        targetHost,
+		Status:      resp.Status,
+		Headers:     resp.Header,
+		BodyPreview: preview.Bytes(),
+		Truncated:   preview.Truncated(),
+	})
 	logger.LogDebug(fmt.Sprintf("HTTP completed: %s %s -> %d", r.Method, r.URL.String(), resp.StatusCode))
 }
 

--- a/internal/proxy/https_handler.go
+++ b/internal/proxy/https_handler.go
@@ -247,7 +247,15 @@ func (h *HTTPSHandler) HandleConnection(conn net.Conn) {
 	if blockList != nil && blockList.Matches(hostname) {
 		logger.LogInfo(fmt.Sprintf("Blocked HTTPS host %s from %s", hostname, sourceIP))
 		reqID := logger.LogTLSRequest(sourceIP, hostname, "TLS SNI")
-		logger.LogHTTPSResponse(reqID, sourceIP, hostname, "BLOCKED", http.Header{}, []byte("Blocked by policy"), false)
+		logger.LogHTTPSResponse(logger.ResponseLogEntry{
+			ReqID:       reqID,
+			SourceIP:    sourceIP,
+			FQDN:        hostname,
+			Status:      "BLOCKED",
+			Headers:     http.Header{},
+			BodyPreview: []byte("Blocked by policy"),
+			Truncated:   false,
+		})
 		return
 	}
 
@@ -401,7 +409,15 @@ func (h *HTTPSHandler) handleHTTPSRequest(tlsConn *tls.Conn, hostname, sourceIP 
 	if err != nil {
 		logger.LogError(fmt.Sprintf("Upstream request failed: %v", err))
 		sendHTTPError(tlsConn, http.StatusBadGateway, "Bad Gateway")
-		logger.LogHTTPSResponse(reqID, sourceIP, hostname, "502 Bad Gateway", http.Header{}, []byte("Bad Gateway"), false)
+		logger.LogHTTPSResponse(logger.ResponseLogEntry{
+			ReqID:       reqID,
+			SourceIP:    sourceIP,
+			FQDN:        hostname,
+			Status:      "502 Bad Gateway",
+			Headers:     http.Header{},
+			BodyPreview: []byte("Bad Gateway"),
+			Truncated:   false,
+		})
 		return
 	}
 	defer resp.Body.Close()
@@ -422,7 +438,15 @@ func (h *HTTPSHandler) handleHTTPSRequest(tlsConn *tls.Conn, hostname, sourceIP 
 			if err != nil {
 				logger.LogError(fmt.Sprintf("Failed reading upstream response body: %v", err))
 				sendHTTPError(tlsConn, http.StatusBadGateway, "Bad Gateway")
-				logger.LogHTTPSResponse(reqID, sourceIP, hostname, "502 Bad Gateway", http.Header{}, []byte("Bad Gateway"), false)
+				logger.LogHTTPSResponse(logger.ResponseLogEntry{
+					ReqID:       reqID,
+					SourceIP:    sourceIP,
+					FQDN:        hostname,
+					Status:      "502 Bad Gateway",
+					Headers:     http.Header{},
+					BodyPreview: []byte("Bad Gateway"),
+					Truncated:   false,
+				})
 				return
 			}
 
@@ -449,7 +473,15 @@ func (h *HTTPSHandler) handleHTTPSRequest(tlsConn *tls.Conn, hostname, sourceIP 
 					logger.LogError(fmt.Sprintf("Failed to write response to client: %v", err))
 					return
 				}
-				logger.LogHTTPSResponse(reqID, sourceIP, hostname, resp.Status, resp.Header, preview.Bytes(), preview.Truncated())
+				logger.LogHTTPSResponse(logger.ResponseLogEntry{
+					ReqID:       reqID,
+					SourceIP:    sourceIP,
+					FQDN:        hostname,
+					Status:      resp.Status,
+					Headers:     resp.Header,
+					BodyPreview: preview.Bytes(),
+					Truncated:   preview.Truncated(),
+				})
 				logger.LogDebug(fmt.Sprintf("HTTPS completed (tampered): %s %s -> %d", req.Method, fullURL, resp.StatusCode))
 				return
 			}
@@ -464,7 +496,15 @@ func (h *HTTPSHandler) handleHTTPSRequest(tlsConn *tls.Conn, hostname, sourceIP 
 		logger.LogError(fmt.Sprintf("Failed to write response to client: %v", err))
 		return
 	}
-	logger.LogHTTPSResponse(reqID, sourceIP, hostname, resp.Status, resp.Header, preview.Bytes(), preview.Truncated())
+	logger.LogHTTPSResponse(logger.ResponseLogEntry{
+		ReqID:       reqID,
+		SourceIP:    sourceIP,
+		FQDN:        hostname,
+		Status:      resp.Status,
+		Headers:     resp.Header,
+		BodyPreview: preview.Bytes(),
+		Truncated:   preview.Truncated(),
+	})
 
 	logger.LogDebug(fmt.Sprintf("HTTPS completed: %s %s -> %d", req.Method, fullURL, resp.StatusCode))
 }


### PR DESCRIPTION
🎯 **What:** The code health issue addressed is the high parameter count in `LogHTTPResponse` and `LogHTTPSResponse`.
💡 **Why:** Encapsulating parameters into a `ResponseLogEntry` struct improves the maintainability and readability of the codebase by simplifying function signatures and making it easier to add or modify parameters in the future without breaking existing calls.
✅ **Verification:** Verified by ensuring the code compiles successfully (`go build ./...`) and all tests pass (`go test ./...`). No functionality was changed.
✨ **Result:** A cleaner and more maintainable logging API.

---
*PR created automatically by Jules for task [17671272076181662033](https://jules.google.com/task/17671272076181662033) started by @dmitryporotnikov*